### PR TITLE
Add CaseInsensitiveTextField to utilize the PostgreSQL CITEXT type

### DIFF
--- a/django_postgres/__init__.py
+++ b/django_postgres/__init__.py
@@ -1,2 +1,3 @@
 from django_postgres.view import View
 from django_postgres.bitstrings import BitStringField, BitStringExpression as B, Bits
+from django_postgres.citext import CaseInsensitiveTextField

--- a/django_postgres/citext.py
+++ b/django_postgres/citext.py
@@ -1,0 +1,7 @@
+from django.db.models import fields
+
+
+class CaseInsensitiveTextField(fields.TextField):
+
+    def db_type(self, connection):
+        return "citext"


### PR DESCRIPTION
This fixes #6 by adding the `CaseInsensitiveTextField` type.
